### PR TITLE
Improve Choc support

### DIFF
--- a/klavgen/__init__.py
+++ b/klavgen/__init__.py
@@ -51,6 +51,7 @@ from .config import (
     ControllerConfig,
     KailhMXSocketConfig,
     MXKeyConfig,
+    ChocKeyConfig,
     MXSwitchHolderConfig,
     ChocSwitchHolderConfig,
     TrrsJackConfig,

--- a/klavgen/config.py
+++ b/klavgen/config.py
@@ -54,6 +54,9 @@ class ChocKeyConfig(MXKeyConfig):
     keycap_width: float = 17.5
     keycap_depth: float = 16.5
 
+    # Case tile
+    case_tile_margin: float = 8.1  # Bump up to produce same outlines as MX
+
 
 @dataclass
 class CaseConfig:


### PR DESCRIPTION
* Increase the default Choc key case margin from 8 to 8.1 so Choc keys produce the same case outlines as MX keys
* Expose ChocKeyConfig at the package level
